### PR TITLE
Add ability to regenerate a unique token with the same options

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ To generate a unique-random on the fly `Uniqueness.generate` that will produce a
 
 You can also pass some options `Uniqueness.generate(type: :human)`.
 
+To regenerate a unique-random value with the same options `example.regenerate_foo`.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/gemfiles/40.gemfile
+++ b/gemfiles/40.gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 gem "rails", "~> 4.0.0"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/40.gemfile.lock
+++ b/gemfiles/40.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    uniqueness (0.7.0)
+    uniqueness (0.8.0)
       activerecord (>= 4.0.0)
       railties (>= 4.0.0)
 
@@ -121,4 +121,4 @@ DEPENDENCIES
   uniqueness!
 
 BUNDLED WITH
-   1.14.6
+   1.16.1

--- a/gemfiles/41.gemfile
+++ b/gemfiles/41.gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 gem "rails", "~> 4.1.0"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/41.gemfile.lock
+++ b/gemfiles/41.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    uniqueness (0.7.0)
+    uniqueness (0.8.0)
       activerecord (>= 4.0.0)
       railties (>= 4.0.0)
 
@@ -125,4 +125,4 @@ DEPENDENCIES
   uniqueness!
 
 BUNDLED WITH
-   1.14.6
+   1.16.1

--- a/gemfiles/42.gemfile
+++ b/gemfiles/42.gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 gem "rails", "~> 4.2.0"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/42.gemfile.lock
+++ b/gemfiles/42.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    uniqueness (0.7.0)
+    uniqueness (0.8.0)
       activerecord (>= 4.0.0)
       railties (>= 4.0.0)
 
@@ -150,4 +150,4 @@ DEPENDENCIES
   uniqueness!
 
 BUNDLED WITH
-   1.14.6
+   1.16.1

--- a/gemfiles/50.gemfile
+++ b/gemfiles/50.gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 gem "rails", "5.0.0.beta3"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/50.gemfile.lock
+++ b/gemfiles/50.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    uniqueness (0.7.0)
+    uniqueness (0.8.0)
       activerecord (>= 4.0.0)
       railties (>= 4.0.0)
 
@@ -160,4 +160,4 @@ DEPENDENCIES
   uniqueness!
 
 BUNDLED WITH
-   1.14.6
+   1.16.1

--- a/lib/uniqueness/model.rb
+++ b/lib/uniqueness/model.rb
@@ -34,6 +34,7 @@ module Uniqueness
         self.uniqueness_options[name] = Uniqueness.uniqueness_default_options.merge(options)
         before_validation :uniqueness_generate
         validate :uniqueness_validation
+        define_method("regenerate_#{name}") { update_attributes(name => Uniqueness.generate(self.uniqueness_options[name])) }
       end
     end
 

--- a/spec/uniqueness/uniqueness_spec.rb
+++ b/spec/uniqueness/uniqueness_spec.rb
@@ -16,7 +16,7 @@ describe Uniqueness do
       it { expect(page.token.length).to eq 12 }
     end
 
-    context 'excludes ambigious characters from human field', focus: true do
+    context 'excludes ambigious characters from human field' do
       it { expect(page.short_code.split).not_to include Uniqueness.uniqueness_ambigious_dictionary  }
     end
   end
@@ -31,6 +31,34 @@ describe Uniqueness do
         page.save
       end
       it { expect(page.uid).to eq old_uid }
+    end
+  end
+
+  context 'regenerate' do
+    it { expect(page.uid).not_to be_nil }
+    it { expect(page.short_code).not_to be_nil }
+    it { expect(page.token).not_to be_nil }
+
+    context 'regenerates a new unique value' do
+      let!(:old_uid) { page.uid }
+      before { page.regenerate_uid }
+
+      it { expect(page.uid).not_to eq old_uid }
+    end
+
+    context 'regenerates a new unique value with the same options' do
+      let!(:old_short_code) { page.short_code }
+      let!(:old_token) { page.token }
+      before do
+        page.regenerate_short_code
+        page.regenerate_token
+      end
+
+      it { expect(page.short_code).not_to eq old_short_code }
+      it { expect(page.short_code.length).to eq 9 }
+      it { expect(page.short_code.split).not_to include Uniqueness.uniqueness_ambigious_dictionary  }
+      it { expect(page.token).not_to eq old_token }
+      it { expect(page.token.length).to eq 12 }
     end
   end
 end


### PR DESCRIPTION
Adds the ability to regenerate a unique token with the same options.

Example:

    class Example < ActiveRecord::Base
      has_unique_field :token, length: 12
    end

    example = Example.create
    example.token # 2RCYqmsZ7dYG

    example.regenerate_token # true
    example.token # P2WRSQjhYYkq
    # generated a new unique token with the same length