### PR TITLE
Allow set when the generator to be triggered

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ To auto-generate a new random string for field `foo`:
 You can customize the generated string by
 passing an options hash. The following keys are supported:
 
+`:trigger_on` when to be generated, can be one of ActiveRecord callbacks (`before_validation`, `before_create`, `before_save`, `after_initialize`), default to __:before_validation__
+
 `:length` number of characters, defaults to __32__
 
 `:type` type of string, can be one of: `:human`, `:auto`, defaults to __:auto__

--- a/lib/uniqueness/generator.rb
+++ b/lib/uniqueness/generator.rb
@@ -34,7 +34,8 @@ module Uniqueness
         blacklist: [],
         scope: [],
         suffix: '',
-        prefix: ''
+        prefix: '',
+        trigger_on: :before_validation
       }
     end
   end

--- a/lib/uniqueness/model.rb
+++ b/lib/uniqueness/model.rb
@@ -46,7 +46,7 @@ module Uniqueness
         end
 
         validate :uniqueness_validation
-        define_method("regenerate_#{name}") { self.update("#{name}": Uniqueness.generate(self.uniqueness_options[name])) }
+        define_method("regenerate_#{name}") { update(name => Uniqueness.generate(self.uniqueness_options[name])) }
       end
     end
 

--- a/lib/uniqueness/model.rb
+++ b/lib/uniqueness/model.rb
@@ -16,6 +16,7 @@ module Uniqueness
       #   You can customize the generated string by
       #   passing an options hash. The following keys are supported:
       #
+      #   +:trigger_on+ when to be generated, can be one of ActiveRecord callbacks (<tt>before_validation</tt>, <tt>before_create</tt>, <tt>before_save</tt>, <tt>after_initialize</tt>), default to <tt>:before_validation</tt>
       #   +:length+ number of characters, defaults to <tt>32</tt>
       #
       #   +:case_sensitive+ defaults to <tt>true</tt>
@@ -32,10 +33,20 @@ module Uniqueness
       def has_unique_field(name, options = {})
         self.uniqueness_options ||= {}
         self.uniqueness_options[name] = Uniqueness.uniqueness_default_options.merge(options)
-        before_validation :uniqueness_generate
+
+        case options[:trigger_on]
+        when :before_create
+          before_create :uniqueness_generate
+        when :before_save
+          before_save :uniqueness_generate
+        when :after_initialize
+          after_initialize :uniqueness_generate
+        else
+          before_validation :uniqueness_generate
+        end
+
         validate :uniqueness_validation
-        # TODO: we need to use update instead of update_attributes as it'll be depricated from rails 6.1
-        define_method("regenerate_#{name}") { update_attributes(name => Uniqueness.generate(self.uniqueness_options[name])) }
+        define_method("regenerate_#{name}") { self.update("#{name}": Uniqueness.generate(self.uniqueness_options[name])) }
       end
     end
 

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -3,5 +3,10 @@ ActiveRecord::Schema.define version: 0 do
     t.string :uid
     t.string :short_code
     t.string :token
+    t.string :after_init_token
+  end
+
+  create_table :new_pages, force: true do |t|
+    t.string :after_init_token
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,10 @@ class Page < ActiveRecord::Base
   has_unique_field :token, length: 12, type: :url
 end
 
+class NewPage < ActiveRecord::Base
+  has_unique_field :after_init_token, trigger_on: :after_initialize
+end
+
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.filter_run focus: true

--- a/spec/uniqueness/uniqueness_spec.rb
+++ b/spec/uniqueness/uniqueness_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe Uniqueness do
   let(:page) { Page.create }
+  let(:new_page) { NewPage.new }
 
   context 'create' do
     it { expect(page.uid).not_to be_nil }
@@ -59,6 +60,25 @@ describe Uniqueness do
       it { expect(page.short_code.split).not_to include Uniqueness.uniqueness_ambigious_dictionary  }
       it { expect(page.token).not_to eq old_token }
       it { expect(page.token.length).to eq 12 }
+    end
+  end
+
+  context 'intialized new object' do
+    it { expect(new_page.after_init_token).not_to be_nil }
+
+    context 'length' do
+      it 'defaults to 32' do
+        expect(new_page.after_init_token.length).to eq 32
+      end
+
+      it 'new_page to be new record and not persisted' do
+        expect(new_page.new_record?).to be_truthy
+        expect(new_page.id).to be_nil
+      end
+    end
+
+    context 'excludes ambiguous characters from human field' do
+      it { expect(page.short_code.split).not_to include Uniqueness.uniqueness_ambigious_dictionary  }
     end
   end
 end


### PR DESCRIPTION
- Allow passing the which AR callback to be trigger the generator with.
- Use update instead of update_attributes as it'll be deprecated from rails 6.1